### PR TITLE
fix_bug

### DIFF
--- a/src/pages/main/layout/ui/footer/nav/FooterNav.module.css
+++ b/src/pages/main/layout/ui/footer/nav/FooterNav.module.css
@@ -48,7 +48,7 @@
     align-items: flex-end;
     gap: 8px;
     transform: translateX(-2px);
-    width: 138px; /* точная ширина меню из Figma */
+    width: 140px; /* точная ширина меню из Figma */
   }
   .footerNavLink {
     font-size: 16px;


### PR DESCRIPTION
Исправлено замечание:
Кнопка "Контактирајте нас" прописана в одну строку

BUG_28 [Frontend] Переносится текст кнопки "Контактирајте нас" на вторую строку в футере при сербском (кириллица) переводе https://github.com/orgs/Masterskaya-Ambasada/projects/1/views/1?pane=issue&itemId=210971611&issue=Masterskaya-Ambasada%7CAmbasada-frontend%7C170